### PR TITLE
Improve CI, migrate to slog, simplify auth, and add scheduled maintenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,38 +9,58 @@ permissions:
 
 jobs:
   release:
-    name: Tag & Release
+    name: Release (${{ matrix.module }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: [common, echo, gin]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Get latest tag
+      - name: Get latest module tag
         id: latest_tag
         run: |
-          latest=$(git tag -l 'v*' --sort=-v:refname | head -n 1)
-          echo "tag=${latest:-v0.0.0}" >> "$GITHUB_OUTPUT"
+          latest=$(git tag -l '${{ matrix.module }}/v*' --sort=-v:refname | head -n 1)
+          echo "tag=${latest}" >> "$GITHUB_OUTPUT"
+          echo "version=${latest#${{ matrix.module }}/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Check for changes
+        id: changes
+        run: |
+          tag="${{ steps.latest_tag.outputs.tag }}"
+          if [ -z "$tag" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "${tag}..HEAD" -- ${{ matrix.module }}/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Bump version
+        if: steps.changes.outputs.changed == 'true'
         id: bump
         run: |
-          current="${{ steps.latest_tag.outputs.tag }}"
-          current="${current#v}"
-          IFS='.' read -r major minor patch <<< "$current"
-          patch=$((patch + 1))
-          new_tag="v${major}.${minor}.${patch}"
+          current="${{ steps.latest_tag.outputs.version }}"
+          if [ -z "$current" ]; then
+            new_tag="${{ matrix.module }}/v0.1.0"
+          else
+            IFS='.' read -r major minor patch <<< "$current"
+            patch=$((patch + 1))
+            new_tag="${{ matrix.module }}/v${major}.${minor}.${patch}"
+          fi
           echo "new_tag=${new_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes
+        if: steps.changes.outputs.changed == 'true'
         id: notes
         run: |
           prev_tag="${{ steps.latest_tag.outputs.tag }}"
-          new_tag="${{ steps.bump.outputs.new_tag }}"
-          if git rev-parse "$prev_tag" >/dev/null 2>&1; then
-            log=$(git log "${prev_tag}..HEAD" --pretty=format:"- %s (%h)" --no-merges)
+          if [ -n "$prev_tag" ] && git rev-parse "$prev_tag" >/dev/null 2>&1; then
+            log=$(git log "${prev_tag}..HEAD" --pretty=format:"- %s (%h)" --no-merges -- ${{ matrix.module }}/)
           else
-            log=$(git log --pretty=format:"- %s (%h)" --no-merges)
+            log=$(git log --pretty=format:"- %s (%h)" --no-merges -- ${{ matrix.module }}/)
           fi
           {
             echo "notes<<EOF"
@@ -48,15 +68,14 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create tag
+      - name: Create tag and release
+        if: steps.changes.outputs.changed == 'true'
         run: |
           git tag "${{ steps.bump.outputs.new_tag }}"
-          git tag "common/${{ steps.bump.outputs.new_tag }}"
-          git tag "echo/${{ steps.bump.outputs.new_tag }}"
-          git tag "gin/${{ steps.bump.outputs.new_tag }}"
-          git push origin --tags
+          git push origin "${{ steps.bump.outputs.new_tag }}"
 
       - name: Create GitHub release
+        if: steps.changes.outputs.changed == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.bump.outputs.new_tag }}

--- a/common/authentication.go
+++ b/common/authentication.go
@@ -1,9 +1,9 @@
 package common
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -22,13 +22,8 @@ func GetBearerToken(r *http.Request) string {
 	return token
 }
 
-func logAuthError(msg string) {
-	escaped, _ := json.Marshal(msg)
-	fmt.Printf("{\"module\":\"jwt-auth\", \"error\":%s}\n", escaped)
-}
-
 func JWTKeyFunc(key string, symmetric bool) jwt.Keyfunc {
-	return func(token *jwt.Token) (interface{}, error) {
+	return func(token *jwt.Token) (any, error) {
 		if symmetric {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -40,7 +35,7 @@ func JWTKeyFunc(key string, symmetric bool) jwt.Keyfunc {
 		}
 		verifyKey, err := jwt.ParseRSAPublicKeyFromPEM([]byte(key))
 		if err != nil {
-			logAuthError(err.Error())
+			slog.Error("failed to parse RSA public key", "module", "jwt-auth", "error", err)
 			return nil, err
 		}
 		return verifyKey, nil

--- a/common/authentication_test.go
+++ b/common/authentication_test.go
@@ -75,14 +75,14 @@ func TestGetBearerToken(t *testing.T) {
 func TestJWTKeyFunc(t *testing.T) {
 	t.Run("symmetric returns key bytes", func(t *testing.T) {
 		keyFunc := JWTKeyFunc("mysecret", true)
-		result, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodHS256, Header: map[string]interface{}{"alg": "HS256"}})
+		result, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodHS256, Header: map[string]any{"alg": "HS256"}})
 		assert.Nil(t, err)
 		assert.Equal(t, []byte("mysecret"), result)
 	})
 
 	t.Run("symmetric rejects RSA algorithm", func(t *testing.T) {
 		keyFunc := JWTKeyFunc("mysecret", true)
-		result, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodRS256, Header: map[string]interface{}{"alg": "RS256"}})
+		result, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodRS256, Header: map[string]any{"alg": "RS256"}})
 		assert.NotNil(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "unexpected signing method")
@@ -90,7 +90,7 @@ func TestJWTKeyFunc(t *testing.T) {
 
 	t.Run("asymmetric rejects HMAC algorithm", func(t *testing.T) {
 		keyFunc := JWTKeyFunc("not-a-valid-pem", false)
-		result, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodHS256, Header: map[string]interface{}{"alg": "HS256"}})
+		result, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodHS256, Header: map[string]any{"alg": "HS256"}})
 		assert.NotNil(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "unexpected signing method")
@@ -98,7 +98,7 @@ func TestJWTKeyFunc(t *testing.T) {
 
 	t.Run("asymmetric with invalid PEM", func(t *testing.T) {
 		keyFunc := JWTKeyFunc("not-a-valid-pem", false)
-		result, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodRS256, Header: map[string]interface{}{"alg": "RS256"}})
+		result, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodRS256, Header: map[string]any{"alg": "RS256"}})
 		assert.NotNil(t, err)
 		assert.Nil(t, result)
 	})

--- a/echo/authentication.go
+++ b/echo/authentication.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"crypto/subtle"
+	"log/slog"
 	"net/http"
 
 	"github.com/golang-jwt/jwt"
@@ -17,28 +18,13 @@ func JWTAuthValidatorMiddleware(key, unauthorizedErrorMessage string, symmetric,
 			}
 
 			token, err := jwt.Parse(bearerToken, jwtKeyFunc(key, symmetric))
-
-			var errorMessage string
-			switch vErr := err.(type) {
-			case nil:
-				if !token.Valid {
-					errorMessage = "invalid token"
-				}
-			case *jwt.ValidationError:
-				switch vErr.Errors {
-				case jwt.ValidationErrorExpired:
-					errorMessage = "token expired"
-				default:
-					errorMessage = "token ValidationError error: " + vErr.Error()
-				}
-			default:
-				errorMessage = "token parse error: " + err.Error()
-			}
-
-			if errorMessage != "" {
+			if err != nil {
 				if logErrorMessage {
-					logAuthError(err.Error())
+					slog.Error("authentication failed", "module", "jwt-auth", "error", err)
 				}
+				return echo.NewHTTPError(http.StatusUnauthorized, unauthorizedErrorMessage)
+			}
+			if !token.Valid {
 				return echo.NewHTTPError(http.StatusUnauthorized, unauthorizedErrorMessage)
 			}
 

--- a/echo/helper.go
+++ b/echo/helper.go
@@ -1,8 +1,8 @@
 package echo
 
 import (
-	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -17,13 +17,8 @@ func getBearerToken(r *http.Request) string {
 	return token
 }
 
-func logAuthError(msg string) {
-	escaped, _ := json.Marshal(msg)
-	fmt.Printf("{\"module\":\"jwt-auth\", \"error\":%s}\n", escaped)
-}
-
 func jwtKeyFunc(key string, symmetric bool) jwt.Keyfunc {
-	return func(token *jwt.Token) (interface{}, error) {
+	return func(token *jwt.Token) (any, error) {
 		if symmetric {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -35,7 +30,7 @@ func jwtKeyFunc(key string, symmetric bool) jwt.Keyfunc {
 		}
 		verifyKey, err := jwt.ParseRSAPublicKeyFromPEM([]byte(key))
 		if err != nil {
-			logAuthError(err.Error())
+			slog.Error("failed to parse RSA public key", "module", "jwt-auth", "error", err)
 			return nil, err
 		}
 		return verifyKey, nil

--- a/echo/maintenance.go
+++ b/echo/maintenance.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
@@ -9,16 +10,32 @@ import (
 func ProbeMaintenanceMiddleware(skippedPaths []string, errorMessage string, statusCode int, enabled bool) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			if enabled {
-				for _, skippedPath := range skippedPaths {
-					if strings.HasPrefix(c.Request().URL.Path, skippedPath) {
-						return next(c)
-					}
-				}
-				return echo.NewHTTPError(statusCode, map[string]string{"message": errorMessage})
+			if !enabled {
+				return next(c)
 			}
+			for _, skippedPath := range skippedPaths {
+				if strings.HasPrefix(c.Request().URL.Path, skippedPath) {
+					return next(c)
+				}
+			}
+			return echo.NewHTTPError(statusCode, map[string]string{"message": errorMessage})
+		}
+	}
+}
 
-			return next(c)
+func ScheduledMaintenanceMiddleware(skippedPaths []string, errorMessage string, statusCode int, from, to time.Time) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			now := time.Now()
+			if (from.IsZero() && to.IsZero()) || now.Before(from) || (!to.IsZero() && now.After(to)) {
+				return next(c)
+			}
+			for _, skippedPath := range skippedPaths {
+				if strings.HasPrefix(c.Request().URL.Path, skippedPath) {
+					return next(c)
+				}
+			}
+			return echo.NewHTTPError(statusCode, map[string]string{"message": errorMessage})
 		}
 	}
 }

--- a/echo/maintenance_test.go
+++ b/echo/maintenance_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -104,5 +105,135 @@ func TestProbeMaintenanceMiddleware(t *testing.T) {
 		rec2 := httptest.NewRecorder()
 		e.ServeHTTP(rec2, req2)
 		assert.Equal(t, http.StatusServiceUnavailable, rec2.Code)
+	})
+}
+
+func setupEchoScheduledMaintenance(skippedPaths []string, errMsg string, statusCode int, from, to time.Time) *echo.Echo {
+	e := echo.New()
+	e.Use(ScheduledMaintenanceMiddleware(skippedPaths, errMsg, statusCode, from, to))
+	e.GET("/", func(c echo.Context) error {
+		return c.String(http.StatusOK, "Hello World")
+	})
+	e.GET("/api/allowed", func(c echo.Context) error {
+		return c.String(http.StatusOK, "Allowed")
+	})
+	e.GET("/health", func(c echo.Context) error {
+		return c.String(http.StatusOK, "OK")
+	})
+	return e
+}
+
+func TestScheduledMaintenanceMiddleware(t *testing.T) {
+	t.Run("before window passes through", func(t *testing.T) {
+		from := time.Now().Add(1 * time.Hour)
+		to := time.Now().Add(2 * time.Hour)
+		e := setupEchoScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "Hello World", rec.Body.String())
+	})
+
+	t.Run("after window passes through", func(t *testing.T) {
+		from := time.Now().Add(-2 * time.Hour)
+		to := time.Now().Add(-1 * time.Hour)
+		e := setupEchoScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "Hello World", rec.Body.String())
+	})
+
+	t.Run("within window blocks requests", func(t *testing.T) {
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+		e := setupEchoScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		assert.Contains(t, rec.Body.String(), "Under Maintenance")
+	})
+
+	t.Run("within window allows skipped path", func(t *testing.T) {
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+		e := setupEchoScheduledMaintenance([]string{"/health"}, "Under Maintenance", http.StatusServiceUnavailable, from, to)
+
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "OK", rec.Body.String())
+
+		req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec2 := httptest.NewRecorder()
+		e.ServeHTTP(rec2, req2)
+		assert.Equal(t, http.StatusServiceUnavailable, rec2.Code)
+	})
+
+	t.Run("custom status code", func(t *testing.T) {
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+		e := setupEchoScheduledMaintenance(nil, "Try Later", http.StatusUnprocessableEntity, from, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	})
+
+	t.Run("both zero times passes through", func(t *testing.T) {
+		e := setupEchoScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, time.Time{}, time.Time{})
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("zero from with future to blocks", func(t *testing.T) {
+		to := time.Now().Add(1 * time.Hour)
+		e := setupEchoScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, time.Time{}, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	})
+
+	t.Run("zero from with past to passes through", func(t *testing.T) {
+		to := time.Now().Add(-1 * time.Hour)
+		e := setupEchoScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, time.Time{}, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("past from with zero to blocks indefinitely", func(t *testing.T) {
+		from := time.Now().Add(-1 * time.Hour)
+		e := setupEchoScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, time.Time{})
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	})
+
+	t.Run("future from with zero to passes through", func(t *testing.T) {
+		from := time.Now().Add(1 * time.Hour)
+		e := setupEchoScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, time.Time{})
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
 	})
 }

--- a/gin/authentication.go
+++ b/gin/authentication.go
@@ -2,6 +2,7 @@ package gin
 
 import (
 	"crypto/subtle"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -18,28 +19,15 @@ func JWTAuthValidatorMiddleware(key, unauthorizedErrorMessage string, symmetric,
 		}
 
 		token, err := jwt.Parse(bearerToken, jwtKeyFunc(key, symmetric))
-
-		var errorMessage string
-		switch vErr := err.(type) {
-		case nil:
-			if !token.Valid {
-				errorMessage = "invalid token"
-			}
-		case *jwt.ValidationError:
-			switch vErr.Errors {
-			case jwt.ValidationErrorExpired:
-				errorMessage = "token expired"
-			default:
-				errorMessage = "token ValidationError error: " + vErr.Error()
-			}
-		default:
-			errorMessage = "token parse error: " + err.Error()
-		}
-
-		if errorMessage != "" {
+		if err != nil {
 			if logErrorMessage {
-				logAuthError(err.Error())
+				slog.Error("authentication failed", "module", "jwt-auth", "error", err)
 			}
+			c.JSON(http.StatusUnauthorized, gin.H{"message": unauthorizedErrorMessage})
+			c.Abort()
+			return
+		}
+		if !token.Valid {
 			c.JSON(http.StatusUnauthorized, gin.H{"message": unauthorizedErrorMessage})
 			c.Abort()
 			return

--- a/gin/helper.go
+++ b/gin/helper.go
@@ -1,8 +1,8 @@
 package gin
 
 import (
-	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -17,13 +17,8 @@ func getBearerToken(r *http.Request) string {
 	return token
 }
 
-func logAuthError(msg string) {
-	escaped, _ := json.Marshal(msg)
-	fmt.Printf("{\"module\":\"jwt-auth\", \"error\":%s}\n", escaped)
-}
-
 func jwtKeyFunc(key string, symmetric bool) jwt.Keyfunc {
-	return func(token *jwt.Token) (interface{}, error) {
+	return func(token *jwt.Token) (any, error) {
 		if symmetric {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -35,7 +30,7 @@ func jwtKeyFunc(key string, symmetric bool) jwt.Keyfunc {
 		}
 		verifyKey, err := jwt.ParseRSAPublicKeyFromPEM([]byte(key))
 		if err != nil {
-			logAuthError(err.Error())
+			slog.Error("failed to parse RSA public key", "module", "jwt-auth", "error", err)
 			return nil, err
 		}
 		return verifyKey, nil

--- a/gin/maintenance.go
+++ b/gin/maintenance.go
@@ -2,23 +2,42 @@ package gin
 
 import (
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
 func ProbeMaintenanceMiddleware(skippedPaths []string, errorMessage string, statusCode int, enabled bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if enabled {
-			for _, skippedPath := range skippedPaths {
-				if strings.HasPrefix(c.Request.URL.Path, skippedPath) {
-					c.Next()
-					return
-				}
-			}
-			c.JSON(statusCode, gin.H{"message": errorMessage})
-			c.Abort()
+		if !enabled {
+			c.Next()
 			return
 		}
-		c.Next()
+		for _, skippedPath := range skippedPaths {
+			if strings.HasPrefix(c.Request.URL.Path, skippedPath) {
+				c.Next()
+				return
+			}
+		}
+		c.JSON(statusCode, gin.H{"message": errorMessage})
+		c.Abort()
+	}
+}
+
+func ScheduledMaintenanceMiddleware(skippedPaths []string, errorMessage string, statusCode int, from, to time.Time) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		now := time.Now()
+		if (from.IsZero() && to.IsZero()) || now.Before(from) || (!to.IsZero() && now.After(to)) {
+			c.Next()
+			return
+		}
+		for _, skippedPath := range skippedPaths {
+			if strings.HasPrefix(c.Request.URL.Path, skippedPath) {
+				c.Next()
+				return
+			}
+		}
+		c.JSON(statusCode, gin.H{"message": errorMessage})
+		c.Abort()
 	}
 }

--- a/gin/maintenance_test.go
+++ b/gin/maintenance_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -104,5 +105,135 @@ func TestProbeMaintenanceMiddleware(t *testing.T) {
 		rec2 := httptest.NewRecorder()
 		e.ServeHTTP(rec2, req2)
 		assert.Equal(t, http.StatusServiceUnavailable, rec2.Code)
+	})
+}
+
+func setupGinScheduledMaintenance(skippedPaths []string, errMsg string, statusCode int, from, to time.Time) *gin.Engine {
+	e := gin.New()
+	e.Use(ScheduledMaintenanceMiddleware(skippedPaths, errMsg, statusCode, from, to))
+	e.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "Hello World")
+	})
+	e.GET("/api/allowed", func(c *gin.Context) {
+		c.String(http.StatusOK, "Allowed")
+	})
+	e.GET("/health", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+	return e
+}
+
+func TestScheduledMaintenanceMiddleware(t *testing.T) {
+	t.Run("before window passes through", func(t *testing.T) {
+		from := time.Now().Add(1 * time.Hour)
+		to := time.Now().Add(2 * time.Hour)
+		e := setupGinScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "Hello World", rec.Body.String())
+	})
+
+	t.Run("after window passes through", func(t *testing.T) {
+		from := time.Now().Add(-2 * time.Hour)
+		to := time.Now().Add(-1 * time.Hour)
+		e := setupGinScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "Hello World", rec.Body.String())
+	})
+
+	t.Run("within window blocks requests", func(t *testing.T) {
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+		e := setupGinScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		assert.Contains(t, rec.Body.String(), "Under Maintenance")
+	})
+
+	t.Run("within window allows skipped path", func(t *testing.T) {
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+		e := setupGinScheduledMaintenance([]string{"/health"}, "Under Maintenance", http.StatusServiceUnavailable, from, to)
+
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "OK", rec.Body.String())
+
+		req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec2 := httptest.NewRecorder()
+		e.ServeHTTP(rec2, req2)
+		assert.Equal(t, http.StatusServiceUnavailable, rec2.Code)
+	})
+
+	t.Run("custom status code", func(t *testing.T) {
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+		e := setupGinScheduledMaintenance(nil, "Try Later", http.StatusUnprocessableEntity, from, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	})
+
+	t.Run("both zero times passes through", func(t *testing.T) {
+		e := setupGinScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, time.Time{}, time.Time{})
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("zero from with future to blocks", func(t *testing.T) {
+		to := time.Now().Add(1 * time.Hour)
+		e := setupGinScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, time.Time{}, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	})
+
+	t.Run("zero from with past to passes through", func(t *testing.T) {
+		to := time.Now().Add(-1 * time.Hour)
+		e := setupGinScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, time.Time{}, to)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("past from with zero to blocks indefinitely", func(t *testing.T) {
+		from := time.Now().Add(-1 * time.Hour)
+		e := setupGinScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, time.Time{})
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	})
+
+	t.Run("future from with zero to passes through", func(t *testing.T) {
+		from := time.Now().Add(1 * time.Hour)
+		e := setupGinScheduledMaintenance(nil, "Under Maintenance", http.StatusServiceUnavailable, from, time.Time{})
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
 	})
 }


### PR DESCRIPTION
## Summary
- **Release workflow**: Now versions and releases each submodule independently — only modules with actual changes since their last tag get a new release
- **Logging**: Migrated all `fmt.Printf` hand-rolled JSON logging to `log/slog` structured logging across all three modules
- **Auth middleware**: Simplified JWT validation by replacing the convoluted type-switch error handling with a direct error check (the detailed internal messages were never surfaced to callers anyway)
- **Maintenance middleware**: Flattened with early returns; added `ScheduledMaintenanceMiddleware` with `from`/`to` time window support where zero values act as unbounded on that side
- **Modernization**: Replaced `interface{}` with `any` across all modules

## Test plan
- [x] All existing tests pass (`go test ./... -race -count=1` across all modules)
- [x] New `ScheduledMaintenanceMiddleware` tests cover: before/after/within window, skipped paths, custom status codes, zero from, zero to, both zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)