### PR TITLE
Add JWT token generation helpers to common

### DIFF
--- a/common/authentication.go
+++ b/common/authentication.go
@@ -11,11 +11,18 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+// GenerateAuthToken mints an HS256-signed JWT for sub, verifiable via
+// JWTKeyFunc(jwtKey, true). The variadic data is stored under the "data" claim:
+// zero args yield a nil claim (JSON null), and one or more args yield a []any,
+// so a single value still arrives as a one-element slice (consumers must
+// type-assert to []any and index). jwtLifetimeInMinute sets exp relative to
+// iat; values <= 0 mint an already-expired token (intended for tests, not
+// production callers).
 func GenerateAuthToken(sub, jwtKey string, jwtLifetimeInMinute int, data ...any) (string, error) {
 	now := time.Now()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"sub":  sub,
-		"exp":  now.Add(time.Minute * time.Duration(jwtLifetimeInMinute)).Unix(),
+		"exp":  now.Add(time.Duration(jwtLifetimeInMinute) * time.Minute).Unix(),
 		"iat":  now.Unix(),
 		"data": data,
 	})
@@ -29,16 +36,20 @@ func GenerateAuthToken(sub, jwtKey string, jwtLifetimeInMinute int, data ...any)
 	return tokenString, nil
 }
 
+// GenerateAuthTokenAsym mints an RS256-signed JWT for sub using the PEM-encoded
+// RSA private key, verifiable via JWTKeyFunc(publicKeyPEM, false). The "data"
+// claim and jwtLifetimeInMinute behave as documented on GenerateAuthToken.
 func GenerateAuthTokenAsym(sub, jwtPrivKey string, jwtLifetimeInMinute int, data ...any) (string, error) {
 	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtPrivKey))
 	if err != nil {
+		slog.Error("failed to parse RSA private key", "module", "jwt-auth", "error", err)
 		return "", err
 	}
 
 	now := time.Now()
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"sub":  sub,
-		"exp":  now.Add(time.Minute * time.Duration(jwtLifetimeInMinute)).Unix(),
+		"exp":  now.Add(time.Duration(jwtLifetimeInMinute) * time.Minute).Unix(),
 		"iat":  now.Unix(),
 		"data": data,
 	})

--- a/common/authentication.go
+++ b/common/authentication.go
@@ -6,9 +6,51 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
+
+func GenerateAuthToken(sub, jwtKey string, jwtLifetimeInMinute int, data ...any) (string, error) {
+	now := time.Now()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":  sub,
+		"exp":  now.Add(time.Minute * time.Duration(jwtLifetimeInMinute)).Unix(),
+		"iat":  now.Unix(),
+		"data": data,
+	})
+
+	tokenString, err := token.SignedString([]byte(jwtKey))
+	if err != nil {
+		slog.Error("failed to sign token", "module", "jwt-auth", "error", err)
+		return "", err
+	}
+
+	return tokenString, nil
+}
+
+func GenerateAuthTokenAsym(sub, jwtPrivKey string, jwtLifetimeInMinute int, data ...any) (string, error) {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtPrivKey))
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"sub":  sub,
+		"exp":  now.Add(time.Minute * time.Duration(jwtLifetimeInMinute)).Unix(),
+		"iat":  now.Unix(),
+		"data": data,
+	})
+
+	tokenString, err := token.SignedString(signKey)
+	if err != nil {
+		slog.Error("failed to sign token", "module", "jwt-auth", "error", err)
+		return "", err
+	}
+
+	return tokenString, nil
+}
 
 func GetAuthorizationHeaderValue(r *http.Request) string {
 	return r.Header.Get("Authorization")

--- a/common/authentication_test.go
+++ b/common/authentication_test.go
@@ -1,6 +1,10 @@
 package common
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +18,25 @@ func signToken(claims jwt.MapClaims, key string) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signed, _ := token.SignedString([]byte(key))
 	return signed
+}
+
+func generateRSAKeyPair(t *testing.T) (privPEM, pubPEM string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(t, err)
+
+	privPEM = string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	assert.Nil(t, err)
+	pubPEM = string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubBytes,
+	}))
+	return privPEM, pubPEM
 }
 
 func TestGetAuthorizationHeaderValue(t *testing.T) {
@@ -101,6 +124,105 @@ func TestJWTKeyFunc(t *testing.T) {
 		result, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodRS256, Header: map[string]any{"alg": "RS256"}})
 		assert.NotNil(t, err)
 		assert.Nil(t, result)
+	})
+}
+
+func TestGenerateAuthToken(t *testing.T) {
+	key := "mysecret"
+
+	t.Run("round-trips through GetMapClaimsFromJWT", func(t *testing.T) {
+		token, err := GenerateAuthToken("user-1", key, 60, "admin")
+		assert.Nil(t, err)
+		assert.NotEmpty(t, token)
+
+		claims, err := GetMapClaimsFromJWT(key, token, true)
+		assert.Nil(t, err)
+		assert.Equal(t, "user-1", claims["sub"])
+		assert.Equal(t, []any{"admin"}, claims["data"])
+		assert.Contains(t, claims, "iat")
+		assert.Contains(t, claims, "exp")
+	})
+
+	t.Run("sets exp after iat based on lifetime", func(t *testing.T) {
+		token, err := GenerateAuthToken("user-1", key, 30, nil)
+		assert.Nil(t, err)
+
+		claims, err := GetMapClaimsFromJWT(key, token, true)
+		assert.Nil(t, err)
+		iat := int64(claims["iat"].(float64))
+		exp := int64(claims["exp"].(float64))
+		assert.Equal(t, int64(30*60), exp-iat)
+	})
+
+	t.Run("token verified with wrong key fails", func(t *testing.T) {
+		token, err := GenerateAuthToken("user-1", key, 60)
+		assert.Nil(t, err)
+
+		claims, err := GetMapClaimsFromJWT("other-key", token, true)
+		assert.NotNil(t, err)
+		assert.Nil(t, claims)
+	})
+
+	t.Run("expired token rejected on verification", func(t *testing.T) {
+		token, err := GenerateAuthToken("user-1", key, -1)
+		assert.Nil(t, err)
+
+		claims, err := GetMapClaimsFromJWT(key, token, true)
+		assert.NotNil(t, err)
+		assert.Nil(t, claims)
+	})
+}
+
+func TestGenerateAuthTokenAsym(t *testing.T) {
+	privPEM, pubPEM := generateRSAKeyPair(t)
+
+	t.Run("round-trips through GetMapClaimsFromJWT", func(t *testing.T) {
+		token, err := GenerateAuthTokenAsym("user-1", privPEM, 60, "admin")
+		assert.Nil(t, err)
+		assert.NotEmpty(t, token)
+
+		claims, err := GetMapClaimsFromJWT(pubPEM, token, false)
+		assert.Nil(t, err)
+		assert.Equal(t, "user-1", claims["sub"])
+		assert.Equal(t, []any{"admin"}, claims["data"])
+		assert.Contains(t, claims, "iat")
+		assert.Contains(t, claims, "exp")
+	})
+
+	t.Run("sets exp after iat based on lifetime", func(t *testing.T) {
+		token, err := GenerateAuthTokenAsym("user-1", privPEM, 30, nil)
+		assert.Nil(t, err)
+
+		claims, err := GetMapClaimsFromJWT(pubPEM, token, false)
+		assert.Nil(t, err)
+		iat := int64(claims["iat"].(float64))
+		exp := int64(claims["exp"].(float64))
+		assert.Equal(t, int64(30*60), exp-iat)
+	})
+
+	t.Run("invalid private key PEM returns error", func(t *testing.T) {
+		token, err := GenerateAuthTokenAsym("user-1", "not-a-valid-pem", 60)
+		assert.NotNil(t, err)
+		assert.Empty(t, token)
+	})
+
+	t.Run("token verified with wrong public key fails", func(t *testing.T) {
+		token, err := GenerateAuthTokenAsym("user-1", privPEM, 60)
+		assert.Nil(t, err)
+
+		_, otherPub := generateRSAKeyPair(t)
+		claims, err := GetMapClaimsFromJWT(otherPub, token, false)
+		assert.NotNil(t, err)
+		assert.Nil(t, claims)
+	})
+
+	t.Run("expired token rejected on verification", func(t *testing.T) {
+		token, err := GenerateAuthTokenAsym("user-1", privPEM, -1)
+		assert.Nil(t, err)
+
+		claims, err := GetMapClaimsFromJWT(pubPEM, token, false)
+		assert.NotNil(t, err)
+		assert.Nil(t, claims)
 	})
 }
 

--- a/common/authentication_test.go
+++ b/common/authentication_test.go
@@ -154,6 +154,15 @@ func TestGenerateAuthToken(t *testing.T) {
 		assert.Equal(t, int64(30*60), exp-iat)
 	})
 
+	t.Run("no data yields nil claim", func(t *testing.T) {
+		token, err := GenerateAuthToken("user-1", key, 60)
+		assert.Nil(t, err)
+
+		claims, err := GetMapClaimsFromJWT(key, token, true)
+		assert.Nil(t, err)
+		assert.Nil(t, claims["data"])
+	})
+
 	t.Run("token verified with wrong key fails", func(t *testing.T) {
 		token, err := GenerateAuthToken("user-1", key, 60)
 		assert.Nil(t, err)


### PR DESCRIPTION
## Summary
- Add `GenerateAuthToken` (symmetric, HMAC/HS256) and `GenerateAuthTokenAsym` (asymmetric, RSA/RS256) to the `common` module.
- Both mirror the existing `JWTKeyFunc` verification path: symmetric ↔ `JWTKeyFunc(key, true)`, asymmetric ↔ `JWTKeyFunc(key, false)`.
- Claims set: `sub`, `exp`, `iat`, and variadic `data`. A single `time.Now()` is reused for `exp`/`iat`; signing failures are logged via `slog` without leaking the key or token.

## Tests
Added `TestGenerateAuthToken` and `TestGenerateAuthTokenAsym` covering:
- Round-trip through `GetMapClaimsFromJWT`
- `exp - iat == lifetimeMinutes * 60`
- Verification failure with the wrong key
- Expired-token rejection
- (asym) invalid private-key PEM returns an error and empty token

An in-test RSA keypair generator keeps the suite self-contained — no keys checked in.

## Verification
`gofmt`, `go vet`, `staticcheck`, `golangci-lint` (0 issues), and `gosec -tests` (0 issues) all pass; full `common` test suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)